### PR TITLE
[FIX] Rename Network.setRequestInterceptionEnabled

### DIFF
--- a/lib/hpdf/printer.ex
+++ b/lib/hpdf/printer.ex
@@ -100,7 +100,6 @@ defmodule HPDF.Printer do
   def handle_call({:print_pdf, url, _opts}, from, state) do
     method(state.socket, "Page.enable", %{}, 1)
     method(state.socket, "Network.enable", %{}, 2)
-    method(state.socket, "Network.setRequestInterception", %{enabled: true}, 5)
 
     if state.cookie do
       method(state.socket, "Network.setCookie", state.cookie, 8)

--- a/lib/hpdf/printer.ex
+++ b/lib/hpdf/printer.ex
@@ -100,7 +100,7 @@ defmodule HPDF.Printer do
   def handle_call({:print_pdf, url, _opts}, from, state) do
     method(state.socket, "Page.enable", %{}, 1)
     method(state.socket, "Network.enable", %{}, 2)
-    method(state.socket, "Network.setRequestInterceptionEnabled", %{enabled: true}, 5)
+    method(state.socket, "Network.setRequestInterception", %{enabled: true}, 5)
 
     if state.cookie do
       method(state.socket, "Network.setCookie", state.cookie, 8)

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule HPDF.Mixfile do
   @moduledoc false
   use Mix.Project
 
-  @version "0.3.1"
+  @version "0.3.2"
   @url "https://github.com/hassox/hpdf"
   @maintainers [
     "Daniel Neighman",


### PR DESCRIPTION
Rename `Network.setRequestInterceptionEnabled` --> `Network.setRequestInterception` in HPDF.Printer.

This is change from Chromium r511134, if i understood it correctly. Anyway, `Network.setRequestInterceptionEnabled` is no more and causes printing PDF to fail.